### PR TITLE
Enables simplified coordinator node lookup using node name instead of node id

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,57 +129,32 @@ EOF
 
 ### Add a coordinator
 
-In order for the coordinator node to complete a successful handshake with the data nodes, they must agree on the
-data nodes' persistent id and ephemeral_id, which are both generated on startup.
+The coordinator automatically resolves node names to node IDs by reading health data, eliminating the need to manually extract node IDs and ephemeral IDs.
 
 ```bash
-# Get the node ID and ephemeral ID from the first data node.
-% DATA_NODE1_ID=$(curl 'http://localhost:9201/_cluster/state?local' | jq -r '.nodes | keys[0]' )
-% DATA_NODE1_EPHEMERAL_ID=$(curl 'http://localhost:9201/_cluster/state?local' | jq -r ".nodes.[\"${DATA_NODE1_ID}\"].ephemeral_id")
-
-# Get the node ID and ephemeral ID from the second data node.
-% DATA_NODE2_ID=$(curl 'http://localhost:9202/_cluster/state?local' | jq -r '.nodes | keys[0]' )
-% DATA_NODE2_EPHEMERAL_ID=$(curl 'http://localhost:9202/_cluster/state?local' | jq -r ".nodes.[\"${DATA_NODE2_ID}\"].ephemeral_id")
-
-# Tell the coordinator about the data nodes and that shard 0 is on the first data node and shard 1 is on the second.
-# Note that the coordinator will not fetch the index metadata, which is why we must specify the index UUID.
+# Tell the coordinator about the data nodes using their node names (not IDs).
 % cat << EOF | etcdctl put runTask-0
 {
   "remote_shards": {
-    "remote_nodes": [
-      {
-        "node_id": "${DATA_NODE1_ID}",       
-        "ephemeral_id": "${DATA_NODE1_EPHEMERAL_ID}",
-        "address": "127.0.0.1",
-        "port": 9301
-      },
-      {
-        "node_id": "${DATA_NODE2_ID}",       
-        "ephemeral_id": "${DATA_NODE2_EPHEMERAL_ID}",
-        "address": "127.0.0.1",
-        "port": 9302
-      }
-    ],
     "indices": {
       "myindex": {
         "uuid" : "E8F2-ebqQ1-U4SL6NoPEyw",
         "shard_routing" : [
           [
-            {"node_id": "${DATA_NODE1_ID}", "primary": true }
+            {"node_name": "runTask-1", "primary": true }
           ],
           [
-            {"node_id": "${DATA_NODE2_ID}", "primary" : true }
+            {"node_name": "runTask-2", "primary": true }
           ]
         ]
       }
     }
   }
 }
-EOF 
+EOF
 
 # Search via the coordinator node. You'll see both documents added above
 % curl 'http://localhost:9200/myindex/_search?pretty'
-
 
 # Index a batch of documents (surely hitting both shards) via the coordinator node
 % curl -X POST -H 'Content-Type: application/json' http://localhost:9200/myindex/_bulk -d '
@@ -203,7 +178,18 @@ EOF
 
 # Search via the coordinator node. You'll see 10 documents. If you search each data node you'll see around half.
 % curl 'http://localhost:9200/myindex/_search?pretty'
+```
 
+### Heartbeat and Health Data
+
+Nodes automatically publish health and status information to ETCD at the path `{cluster_name}/search-unit/{node_name}/actual-state`.
+
+```bash
+# View heartbeat data for all nodes
+% etcdctl get "runTask/search-unit/" --prefix
+
+# View specific node's health data  
+% etcdctl get "runTask/search-unit/<nodename>/actual-state"
 ```
 
 <img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDHeartbeat.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDHeartbeat.java
@@ -43,7 +43,6 @@ public class ETCDHeartbeat {
     private final Client etcdClient;
     private final ScheduledExecutorService scheduler;
     private final ByteSequence nodeStateKey;
-    private final ByteSequence heartbeatKey;
     private final NodeEnvironment nodeEnvironment;
     private final ClusterService clusterService;
 
@@ -55,11 +54,9 @@ public class ETCDHeartbeat {
         this.port = localNode.getAddress().getPort();
         this.etcdClient = etcdClient;
         this.scheduler = Executors.newSingleThreadScheduledExecutor();
-        // <cluster-name>/search-unit/<search-name>/actual-state
         String clusterName = clusterService.getClusterName().value();
-        this.nodeStateKey = ByteSequence.from(clusterName + "/search-unit/" + nodeName + "/actual-state", StandardCharsets.UTF_8);
-        // heartbeat/<node-name> for coordinator lookup
-        this.heartbeatKey = ByteSequence.from("heartbeat/" + nodeName, StandardCharsets.UTF_8);
+        String statePath = ETCDPathUtils.buildNodeActualStatePath(clusterName, nodeName);
+        this.nodeStateKey = ByteSequence.from(statePath, StandardCharsets.UTF_8);
         this.nodeEnvironment = nodeEnvironment;
         this.clusterService = clusterService;
     }
@@ -152,7 +149,6 @@ public class ETCDHeartbeat {
             
             ByteSequence value = ByteSequence.from(jsonBytes);
             kvClient.put(nodeStateKey, value).get();
-            kvClient.put(heartbeatKey, value).get();
         } catch (InterruptedException | ExecutionException | IOException e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDHeartbeat.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDHeartbeat.java
@@ -38,9 +38,12 @@ public class ETCDHeartbeat {
     private final String nodeName;
     private final String nodeId;
     private final String ephemeralId;
+    private final String address;
+    private final int port;
     private final Client etcdClient;
     private final ScheduledExecutorService scheduler;
     private final ByteSequence nodeStateKey;
+    private final ByteSequence heartbeatKey;
     private final NodeEnvironment nodeEnvironment;
     private final ClusterService clusterService;
 
@@ -48,11 +51,15 @@ public class ETCDHeartbeat {
         this.nodeName = localNode.getName();
         this.nodeId = localNode.getId();
         this.ephemeralId = localNode.getEphemeralId();
+        this.address = localNode.getAddress().getAddress();
+        this.port = localNode.getAddress().getPort();
         this.etcdClient = etcdClient;
         this.scheduler = Executors.newSingleThreadScheduledExecutor();
         // <cluster-name>/search-unit/<search-name>/actual-state
         String clusterName = clusterService.getClusterName().value();
         this.nodeStateKey = ByteSequence.from(clusterName + "/search-unit/" + nodeName + "/actual-state", StandardCharsets.UTF_8);
+        // heartbeat/<node-name> for coordinator lookup
+        this.heartbeatKey = ByteSequence.from("heartbeat/" + nodeName, StandardCharsets.UTF_8);
         this.nodeEnvironment = nodeEnvironment;
         this.clusterService = clusterService;
     }
@@ -111,6 +118,8 @@ public class ETCDHeartbeat {
         heartbeatData.put("nodeName", nodeName);
         heartbeatData.put("nodeId", nodeId);
         heartbeatData.put("ephemeralId", ephemeralId);
+        heartbeatData.put("address", address);
+        heartbeatData.put("port", port);
         heartbeatData.put("heartbeatIntervalSeconds", HEARTBEAT_INTERVAL_SECONDS);
         heartbeatData.put("cpuUsedPercent", cpuPercent);
         heartbeatData.put("memoryUsedPercent", memoryPercent);
@@ -143,6 +152,7 @@ public class ETCDHeartbeat {
             
             ByteSequence value = ByteSequence.from(jsonBytes);
             kvClient.put(nodeStateKey, value).get();
+            kvClient.put(heartbeatKey, value).get();
         } catch (InterruptedException | ExecutionException | IOException e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.etcd;
+
+/**
+ * Utility class for constructing ETCD paths used by the cluster-etcd plugin.
+ */
+public class ETCDPathUtils {
+    
+    /**
+     * Builds the path for a node's actual state in ETCD.
+     * The path pattern is: {cluster_name}/search-unit/{node_name}/actual-state
+     * 
+     * @param clusterName the cluster name
+     * @param nodeName the node name
+     * @return the constructed path as a string
+     */
+    public static String buildNodeActualStatePath(String clusterName, String nodeName) {
+        return clusterName + "/search-unit/" + nodeName + "/actual-state";
+    }
+} 

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
@@ -73,7 +73,7 @@ import java.util.concurrent.ExecutionException;
  * }
  * </pre>
  * 
- * Health check format (stored at heartbeat/{node_name} key):
+ * Health check format (stored at {cluster_name}/search-unit/{node_name}/actual-state):
  * <pre>
  * {
  *   "nodeId": "unique-node-id",
@@ -87,7 +87,6 @@ import java.util.concurrent.ExecutionException;
  */
 public class ETCDStateDeserializer {
     private static final Logger LOGGER = LogManager.getLogger(ETCDStateDeserializer.class);
-    private static final String HEALTH_CHECK_PREFIX = "heartbeat/";
 
     /**
      * Deserializes the node configuration stored in ETCD. Will also read the k/v pairs for each index
@@ -95,12 +94,14 @@ public class ETCDStateDeserializer {
      * <p>
      * For now, let's assume that we store JSON bytes in ETCD.
      *
+     * @param localNode the local discovery node
      * @param byteSequence the serialized node state
-     * @param etcdClient   the ETCD client that we'll use to retrieve index metadata for local shards
+     * @param etcdClient the ETCD client that we'll use to retrieve index metadata for local shards
+     * @param clusterName the cluster name used to build paths for health lookups
      * @return the relevant node state
      */
     @SuppressWarnings("unchecked")
-    public static NodeState deserializeNodeState(DiscoveryNode localNode, ByteSequence byteSequence, Client etcdClient) throws IOException {
+    public static NodeState deserializeNodeState(DiscoveryNode localNode, ByteSequence byteSequence, Client etcdClient, String clusterName) throws IOException {
         Map<String, Object> map;
         try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, byteSequence.getBytes())) {
             map = parser.map();
@@ -112,14 +113,13 @@ public class ETCDStateDeserializer {
             }
             return readDataNodeState(localNode, etcdClient, (Map<String, Map<String, String>>) map.get("local_shards"));
         } else if (map.containsKey("remote_shards")) {
-            return readCoordinatorNodeState(localNode, etcdClient, (Map<String, Object>) map.get("remote_shards"));
+            return readCoordinatorNodeState(localNode, etcdClient, (Map<String, Object>) map.get("remote_shards"), clusterName);
         }
         throw new IllegalStateException("Neither local nor remote shards are present in the node state. Node state should have been removed.");
-
     }
 
     @SuppressWarnings("unchecked")
-    private static CoordinatorNodeState readCoordinatorNodeState(DiscoveryNode localNode, Client etcdClient, Map<String, Object> remoteShards) throws IOException {
+    private static CoordinatorNodeState readCoordinatorNodeState(DiscoveryNode localNode, Client etcdClient, Map<String, Object> remoteShards, String clusterName) throws IOException {
         Map<String, Object> indices = (Map<String, Object>) remoteShards.get("indices");
         Map<String, NodeHealthInfo> nodeHealthMap = new HashMap<>();
         
@@ -137,7 +137,7 @@ public class ETCDStateDeserializer {
             }
         }
         
-        lookupNodeHealthInfo(etcdClient, nodeHealthMap);
+        lookupNodeHealthInfo(etcdClient, nodeHealthMap, clusterName);
         
         List<RemoteNode> remoteNodes = new ArrayList<>();
         for (Map.Entry<String, NodeHealthInfo> entry : nodeHealthMap.entrySet()) {
@@ -213,13 +213,13 @@ public class ETCDStateDeserializer {
     }
 
 
-    private static void lookupNodeHealthInfo(Client etcdClient, Map<String, NodeHealthInfo> nodeHealthMap) throws IOException {
+    private static void lookupNodeHealthInfo(Client etcdClient, Map<String, NodeHealthInfo> nodeHealthMap, String clusterName) throws IOException {
         try (KV kvClient = etcdClient.getKVClient()) {
             List<CompletableFuture<GetResponse>> futures = new ArrayList<>();
             List<String> nodeNames = new ArrayList<>();
             
             for (String nodeName : nodeHealthMap.keySet()) {
-                String healthKey = HEALTH_CHECK_PREFIX + nodeName;
+                String healthKey = ETCDPathUtils.buildNodeActualStatePath(clusterName, nodeName);
                 futures.add(kvClient.get(ByteSequence.from(healthKey, StandardCharsets.UTF_8)));
                 nodeNames.add(nodeName);
             }

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
@@ -52,38 +52,18 @@ import java.util.concurrent.ExecutionException;
  *       }
  *   },
  *   "remote_shards": { // Coordinator node content
- *       "remote_nodes": [ // List of remote nodes that this coordinator node is aware of.
- *         {
- *             "node_id": "node1",
- *             "ephemeral_id": "ephemeral-id-1",
- *             "address": "192.168.2.1",
- *             "port": 9300
- *         },
- *         {
- *             "node_id": "node2",
- *             "ephemeral_id": "ephemeral-id-2",
- *             "address": "192.168.2.2",
- *             "port": 9300
- *         },
- *         {
- *             "node_id": "node3",
- *             "ephemeral_id": "ephemeral-id-3",
- *             "address": "192.168.2.3",
- *             "port": 9300
- *         }
- *       ],
  *       "indices": { // Map of indices that this coordinator node is aware of.
  *          "idx1": {
  *              "uuid": "index-uuid",
  *              "shard_routing": [ // Must have every shard for the index.
  *                  [
- *                    {"node_id":"node1"}
- *                    {"node_id":"node2", "primary": true } // If we have a primary for one shard, we must have a primary for all shards
+ *                    {"node_name":"node1"},
+ *                    {"node_name":"node2", "primary": true } // If we have a primary for one shard, we must have a primary for all shards
  *                  ],
  *                  [ // We don't assume an equal number of replicas for each shard.
- *                    {"node_id":"node1", "primary": true},
- *                    {"node_id":"node2"}, // Any non-primary is assumed to be a search replica.
- *                    {"node_id":"node3"}
+ *                    {"node_name":"node1", "primary": true},
+ *                    {"node_name":"node2"}, // Any non-primary is assumed to be a search replica.
+ *                    {"node_name":"node3"}
  *                  ]
  *              ]
  *          },
@@ -92,9 +72,23 @@ import java.util.concurrent.ExecutionException;
  *   }
  * }
  * </pre>
+ * 
+ * Health check format (stored at heartbeat/{node_name} key):
+ * <pre>
+ * {
+ *   "nodeId": "unique-node-id",
+ *   "ephemeralId": "ephemeral-id-123",
+ *   "address": "xxx.xxx.x.xxx",
+ *   "port": xxxx,
+ *   "timestamp": 1750099493841,
+ *   "heartbeatIntervalSeconds": 5
+ * }
+ * </pre>
  */
 public class ETCDStateDeserializer {
     private static final Logger LOGGER = LogManager.getLogger(ETCDStateDeserializer.class);
+    private static final String HEALTH_CHECK_PREFIX = "heartbeat/";
+
     /**
      * Deserializes the node configuration stored in ETCD. Will also read the k/v pairs for each index
      * referenced from a data node.
@@ -118,43 +112,69 @@ public class ETCDStateDeserializer {
             }
             return readDataNodeState(localNode, etcdClient, (Map<String, Map<String, String>>) map.get("local_shards"));
         } else if (map.containsKey("remote_shards")) {
-            return readCoordinatorNodeState(localNode, (Map<String, Object>) map.get("remote_shards"));
+            return readCoordinatorNodeState(localNode, etcdClient, (Map<String, Object>) map.get("remote_shards"));
         }
         throw new IllegalStateException("Neither local nor remote shards are present in the node state. Node state should have been removed.");
 
     }
 
     @SuppressWarnings("unchecked")
-    private static CoordinatorNodeState readCoordinatorNodeState(DiscoveryNode localNode, Map<String, Object> remoteShards) {
-        List<Map<String, Object>> remoteNodeSpecs = (List<Map<String, Object>>) remoteShards.get("remote_nodes");
-        List<RemoteNode> remoteNodes = new ArrayList<>(remoteNodeSpecs.size());
-        for (Map<String, Object> remoteNodeSpec : remoteNodeSpecs) {
-            String nodeId = (String) remoteNodeSpec.get("node_id");
-            String ephemeralId = (String) remoteNodeSpec.get("ephemeral_id");
-            String address = (String) remoteNodeSpec.get("address");
-            int port = ((Number) remoteNodeSpec.get("port")).intValue();
-            remoteNodes.add(new RemoteNode(nodeId, ephemeralId, address, port));
+    private static CoordinatorNodeState readCoordinatorNodeState(DiscoveryNode localNode, Client etcdClient, Map<String, Object> remoteShards) throws IOException {
+        Map<String, Object> indices = (Map<String, Object>) remoteShards.get("indices");
+        Map<String, NodeHealthInfo> nodeHealthMap = new HashMap<>();
+        
+        for (Map.Entry<String, Object> indexEntry : indices.entrySet()) {
+            Map<String, Object> indexConfig = (Map<String, Object>) indexEntry.getValue();
+            List<List<Map<String, Object>>> shardRouting = (List<List<Map<String, Object>>>) indexConfig.get("shard_routing");
+            
+            for (List<Map<String, Object>> shardEntry : shardRouting) {
+                for (Map<String, Object> nodeEntry : shardEntry) {
+                    String nodeName = (String) nodeEntry.get("node_name");
+                    if (nodeName != null && !nodeHealthMap.containsKey(nodeName)) {
+                        nodeHealthMap.put(nodeName, null); 
+                    }
+                }
+            }
+        }
+        
+        lookupNodeHealthInfo(etcdClient, nodeHealthMap);
+        
+        List<RemoteNode> remoteNodes = new ArrayList<>();
+        for (Map.Entry<String, NodeHealthInfo> entry : nodeHealthMap.entrySet()) {
+            NodeHealthInfo healthInfo = entry.getValue();
+            if (healthInfo != null) {
+                remoteNodes.add(new RemoteNode(healthInfo.nodeId, healthInfo.ephemeralId, healthInfo.address, healthInfo.port));
+            } else {
+                LOGGER.warn("Health information not found for node: {}", entry.getKey());
+            }
         }
 
         Map<Index, List<List<NodeShardAssignment>>> remoteShardAssignment = new HashMap<>();
-        Map<String, Object> indices = (Map<String, Object>) remoteShards.get("indices");
         for (Map.Entry<String, Object> indexEntry : indices.entrySet()) {
             Map<String, Object> indexConfig = (Map<String, Object>) indexEntry.getValue();
             String uuid = (String) indexConfig.get("uuid");
-
             List<List<Map<String, Object>>> shardRouting = (List<List<Map<String, Object>>>) indexConfig.get("shard_routing");
             List<List<NodeShardAssignment>> shardAssignments = new ArrayList<>(shardRouting.size());
+            
             for (List<Map<String, Object>> shardEntry : shardRouting) {
                 List<NodeShardAssignment> nodeShardAssignments = new ArrayList<>();
                 for (Map<String, Object> nodeEntry : shardEntry) {
-                    String nodeId = (String) nodeEntry.get("node_id");
+                    String nodeName = (String) nodeEntry.get("node_name");
                     boolean isPrimary = nodeEntry.containsKey("primary") && (Boolean) nodeEntry.get("primary");
-                    nodeShardAssignments.add(new NodeShardAssignment(nodeId, isPrimary ? ShardRole.PRIMARY : ShardRole.SEARCH_REPLICA));
+                    
+                    NodeHealthInfo healthInfo = nodeHealthMap.get(nodeName);
+                    if (healthInfo != null) {
+                        nodeShardAssignments.add(new NodeShardAssignment(healthInfo.nodeId, isPrimary ? ShardRole.PRIMARY : ShardRole.SEARCH_REPLICA));
+                    } else {
+                        LOGGER.error("Cannot resolve node name '{}' to node ID - health info not available", nodeName);
+                        throw new IllegalStateException("Cannot resolve node name '" + nodeName + "' to node ID");
+                    }
                 }
                 shardAssignments.add(nodeShardAssignments);
             }
             remoteShardAssignment.put(new Index(indexEntry.getKey(), uuid), shardAssignments);
         }
+        
         return new CoordinatorNodeState(localNode, remoteNodes, remoteShardAssignment);
     }
 
@@ -191,4 +211,69 @@ public class ETCDStateDeserializer {
         }
         return new DataNodeState(localNode, indexMetadataMap, localShardAssignment);
     }
+
+
+    private static void lookupNodeHealthInfo(Client etcdClient, Map<String, NodeHealthInfo> nodeHealthMap) throws IOException {
+        try (KV kvClient = etcdClient.getKVClient()) {
+            List<CompletableFuture<GetResponse>> futures = new ArrayList<>();
+            List<String> nodeNames = new ArrayList<>();
+            
+            for (String nodeName : nodeHealthMap.keySet()) {
+                String healthKey = HEALTH_CHECK_PREFIX + nodeName;
+                futures.add(kvClient.get(ByteSequence.from(healthKey, StandardCharsets.UTF_8)));
+                nodeNames.add(nodeName);
+            }
+            
+            for (int i = 0; i < futures.size(); i++) {
+                String nodeName = nodeNames.get(i);
+                try {
+                    GetResponse response = futures.get(i).get();
+                    if (!response.getKvs().isEmpty()) {
+                        KeyValue kv = response.getKvs().get(0);
+                        NodeHealthInfo healthInfo = parseHealthInfo(kv);
+                        nodeHealthMap.put(nodeName, healthInfo);
+                        LOGGER.debug("Resolved node '{}' to ID '{}' with ephemeral ID '{}'", nodeName, healthInfo.nodeId, healthInfo.ephemeralId);
+                    } else {
+                        LOGGER.warn("No health information found for node: {}", nodeName);
+                    }
+                } catch (InterruptedException | ExecutionException e) {
+                    LOGGER.error("Failed to lookup health info for node: {}", nodeName, e);
+                    throw new IOException("Failed to lookup health info for node: " + nodeName, e);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Parses health information from ETCD key-value pair.
+     */
+    @SuppressWarnings("unchecked")
+    private static NodeHealthInfo parseHealthInfo(KeyValue kv) throws IOException {
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, kv.getValue().getBytes())) {
+            Map<String, Object> healthMap = parser.map();
+            
+            String nodeId = (String) healthMap.get("nodeId");
+            String ephemeralId = (String) healthMap.get("ephemeralId");
+            String address = (String) healthMap.get("address");
+            int port = ((Number) healthMap.get("port")).intValue();
+            
+            return new NodeHealthInfo(nodeId, ephemeralId, address, port);
+        }
+    }
+    
+
+    private static class NodeHealthInfo {
+        final String nodeId;
+        final String ephemeralId;
+        final String address;
+        final int port;
+        
+        NodeHealthInfo(String nodeId, String ephemeralId, String address, int port) {
+            this.nodeId = nodeId;
+            this.ephemeralId = ephemeralId;
+            this.address = address;
+            this.port = port;
+        }
+    }
 }
+


### PR DESCRIPTION
### Description
- Updated ETCDHeartbeat.java to include address and port in heartbeat information
- Add heartbeatKey to ETCDHeartbeat.java to publish to heartbeat/ path  
- Enable coordinator configuration using node_name instead of node_id

Overall, these changes allow coordinators can automatically resolve node_name to real node IDs, ephemeral Ids, addresses, and ports without manual configuration
