### PR TITLE
Align cluster-etcd plugin with standardized control plane paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ locally. The first will serve as a coordinator, while the other two will be data
 
 ```bash
 # Write some index metadata for an index. For now, this is the smallest valid metadata I've been able to create.
-% cat << EOF | etcdctl put myindex 
+% cat << EOF | etcdctl put runTask/indices/myindex/conf
 {
   "myindex": {
     "version":1,
@@ -105,10 +105,10 @@ locally. The first will serve as a coordinator, while the other two will be data
 EOF
 
 # Assign primary for shard 0 of myindex to the node listening on port 9201/9301
-% etcdctl put runTask-1 '{"local_shards":{"myindex":{"0":"PRIMARY"}}}'
+% etcdctl put runTask/search-unit/runTask-1/goal-state '{"local_shards":{"myindex":{"0":"PRIMARY"}}}'
 
 # Assign primary for shard 1 of myindex to the node listening on port 9202/9302
-% etcdctl put runTask-2 '{"local_shards":{"myindex":{"1":"PRIMARY"}}}'
+% etcdctl put runTask/search-unit/runTask-2/goal-state '{"local_shards":{"myindex":{"1":"PRIMARY"}}}'
 
 # Check the local cluster state on each data node
 % curl 'http://localhost:9201/_cluster/state?local&pretty'
@@ -133,7 +133,7 @@ The coordinator automatically resolves node names to node IDs by reading health 
 
 ```bash
 # Tell the coordinator about the data nodes using their node names (not IDs).
-% cat << EOF | etcdctl put runTask-0
+% cat << EOF | etcdctl put runTask/search-unit/runTask-0/goal-state
 {
   "remote_shards": {
     "indices": {

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ClusterETCDPlugin.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ClusterETCDPlugin.java
@@ -56,7 +56,7 @@ public class ClusterETCDPlugin extends Plugin implements ClusterPlugin {
             
             String clusterName = clusterService.getClusterName().value();
             
-            etcdWatcher = new ETCDWatcher(localNode, getNodeKey(localNode),
+            etcdWatcher = new ETCDWatcher(localNode, getNodeKey(localNode, clusterName),
                 new ChangeApplierService(clusterService.getClusterApplierService()), etcdClient, clusterName);
             
             etcdHeartbeat = new ETCDHeartbeat(localNode, etcdClient, nodeEnvironment, clusterService);
@@ -66,8 +66,9 @@ public class ClusterETCDPlugin extends Plugin implements ClusterPlugin {
         }
     }
 
-    private ByteSequence getNodeKey(DiscoveryNode localNode) {
-        return ByteSequence.from(localNode.getName(), StandardCharsets.UTF_8);
+    private ByteSequence getNodeKey(DiscoveryNode localNode, String clusterName) {
+        String goalStatePath = ETCDPathUtils.buildSearchUnitGoalStatePath(clusterName, localNode.getName());
+        return ByteSequence.from(goalStatePath, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
@@ -14,11 +14,6 @@ package org.opensearch.cluster.etcd;
  */
 public class ETCDPathUtils {
     
-   
-    public static String buildControlTaskPath(String clusterName, String taskName) {
-        return clusterName + "/ctl-tasks/" + taskName;
-    }
-   
     public static String buildSearchUnitConfigPath(String clusterName, String searchName) {
         return clusterName + "/search-unit/" + searchName + "/conf";
     }

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
@@ -10,18 +10,43 @@ package org.opensearch.cluster.etcd;
 
 /**
  * Utility class for constructing ETCD paths used by the cluster-etcd plugin.
+ * These paths align with the standardized control plane and data plane path structure.
  */
 public class ETCDPathUtils {
     
-    /**
-     * Builds the path for a node's actual state in ETCD.
-     * The path pattern is: {cluster_name}/search-unit/{node_name}/actual-state
-     * 
-     * @param clusterName the cluster name
-     * @param nodeName the node name
-     * @return the constructed path as a string
-     */
-    public static String buildNodeActualStatePath(String clusterName, String nodeName) {
-        return clusterName + "/search-unit/" + nodeName + "/actual-state";
+   
+    public static String buildControlTaskPath(String clusterName, String taskName) {
+        return clusterName + "/ctl-tasks/" + taskName;
     }
+   
+    public static String buildSearchUnitConfigPath(String clusterName, String searchName) {
+        return clusterName + "/search-unit/" + searchName + "/conf";
+    }
+    
+   
+    public static String buildSearchUnitGoalStatePath(String clusterName, String searchName) {
+        return clusterName + "/search-unit/" + searchName + "/goal-state";
+    }
+    
+    public static String buildSearchUnitActualStatePath(String clusterName, String searchName) {
+        return clusterName + "/search-unit/" + searchName + "/actual-state";
+    }
+    
+    public static String buildNodeActualStatePath(String clusterName, String nodeName) {
+        return buildSearchUnitActualStatePath(clusterName, nodeName);
+    }
+    
+    public static String buildIndexConfigPath(String clusterName, String indexName) {
+        return clusterName + "/indices/" + indexName + "/conf";
+    }
+    
+    public static String buildShardPlannedAllocationPath(String clusterName, String indexName, int shardId) {
+        return clusterName + "/indices/" + indexName + "/shard/" + shardId + "/planned-allocation";
+    }
+    
+   
+    public static String buildShardActualAllocationPath(String clusterName, String indexName, int shardId) {
+        return clusterName + "/indices/" + indexName + "/shard/" + shardId + "/actual-allocation";
+    }
+    
 } 


### PR DESCRIPTION

### Description
- **Index metadata**: `myindex` → `/{cluster}/indices/{index}/conf`
- **Node assignments**: `{node}` → `/{cluster}/search-unit/{node}/goal-state`
- **Node reporting**:  `/{cluster}/search-unit/{node}/actual-state`
