### PR TITLE
Implement split metadata architecture for cluster-etcd plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,42 +64,42 @@ locally. The first will serve as a coordinator, while the other two will be data
 
 ### Push some state to etcd to start the data nodes
 
+The cluster-etcd plugin now uses a split metadata approach that separates index configuration into distinct etcd keys:
+
+- **Settings**: `/indices/{index}/settings` - Basic index configuration needed by all nodes
+- **Mappings**: `/indices/{index}/mappings` - Field definitions needed primarily by data nodes  
+
+This approach reduces etcd storage requirements and simplifies control plane logic by filtering out data plane implementation details.
+
 ```bash
-# Write some index metadata for an index. For now, this is the smallest valid metadata I've been able to create.
-% cat << EOF | etcdctl put runTask/indices/myindex/conf
+# Write index settings and mappings separately (new split metadata approach)
+# Settings are needed by both data nodes and coordinators
+% cat << EOF | etcdctl put runTask/indices/myindex/settings
 {
-  "myindex": {
-    "version":1,
-    "mapping_version":1,
-    "settings_version":1,
-    "aliases_version":1,
-    "state":"open",
-    "settings":{
-      "index":{
-        "number_of_shards":"1",
-        "number_of_replicas":"0",
-        "uuid":"E8F2-ebqQ1-U4SL6NoPEyw",
-        "version": {
-          "created":"137227827"
+  "index": {
+    "number_of_shards": "1",
+    "number_of_replicas": "0",
+    "uuid": "E8F2-ebqQ1-U4SL6NoPEyw",
+    "version": {
+      "created": "137227827"
+    }
+  }
+}
+EOF
+
+# Mappings are needed by data nodes only (flattened structure)
+% cat << EOF | etcdctl put runTask/indices/myindex/mappings
+{
+  "properties": {
+    "title": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
         }
       }
-    },
-    "mappings":{
-      "_doc":{
-        "properties":{
-          "title":{
-            "type":"text",
-            "fields":{
-              "keyword":{
-                "type":"keyword",
-                "ignore_above":256
-              }
-            }
-          }
-        }
-      }
-    },
-    "primary_terms":[1,1]
+    }
   }
 }
 EOF
@@ -109,6 +109,13 @@ EOF
 
 # Assign primary for shard 1 of myindex to the node listening on port 9202/9302
 % etcdctl put runTask/search-unit/runTask-2/goal-state '{"local_shards":{"myindex":{"1":"PRIMARY"}}}'
+
+# Verify the split metadata was stored correctly
+% etcdctl get "runTask/indices/myindex/settings"
+% etcdctl get "runTask/indices/myindex/mappings"
+
+# Check all keys to see the new structure
+% etcdctl get "" --from-key --keys-only
 
 # Check the local cluster state on each data node
 % curl 'http://localhost:9201/_cluster/state?local&pretty'

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDIndexMetadataPublisher.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDIndexMetadataPublisher.java
@@ -1,0 +1,197 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.etcd;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KV;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Utility class for publishing index metadata to etcd in split format.
+ * This splits index metadata into separate etcd entries for settings, mappings, and other fields.
+ * 
+ * <p>The control plane can use this to publish index metadata that will be consumed by OpenSearch nodes.
+ * Data nodes will fetch both settings and mappings, while coordinator nodes may only need settings.
+ */
+public class ETCDIndexMetadataPublisher {
+    private static final Logger LOGGER = LogManager.getLogger(ETCDIndexMetadataPublisher.class);
+
+    private final Client etcdClient;
+    private final String clusterName;
+
+    public ETCDIndexMetadataPublisher(Client etcdClient, String clusterName) {
+        this.etcdClient = etcdClient;
+        this.clusterName = clusterName;
+    }
+
+    /**
+     * Publishes complete index metadata to etcd by splitting it into settings, mappings, and other components.
+     * This is the main method for control plane to publish index metadata.
+     * 
+     * @param indexMetadata the complete index metadata to publish
+     * @throws IOException if serialization fails
+     * @throws RuntimeException if etcd operations fail
+     */
+    public void publishIndexMetadata(IndexMetadata indexMetadata) throws IOException {
+        String indexName = indexMetadata.getIndex().getName();
+        
+        LOGGER.debug("Publishing split index metadata for index [{}]", indexName);
+        
+        // Extract and publish settings (needed by both data nodes and coordinators)
+        Settings indexSettings = extractRelevantSettings(indexMetadata.getSettings());
+        publishIndexSettings(indexName, indexSettings);
+        
+        // Extract and publish mappings (needed by data nodes only)
+        MappingMetadata mappingMetadata = indexMetadata.mapping();
+        if (mappingMetadata != null) {
+            publishIndexMappings(indexName, mappingMetadata);
+        }
+        
+        // TODO: Extract and publish other metadata fields if needed (aliases for example)
+        // publishIndexOther(indexName, otherMetadata);
+        
+        LOGGER.debug("Successfully published split index metadata for index [{}]", indexName);
+    }
+
+    /**
+     * Publishes only index settings to etcd.
+     * 
+     * @param indexName the name of the index
+     * @param settings the index settings to publish
+     * 
+     */
+    public void publishIndexSettings(String indexName, Settings settings) throws IOException {
+        String settingsPath = ETCDPathUtils.buildIndexSettingsPath(clusterName, indexName);
+        
+        // Serialize settings to JSON
+        ByteArrayOutputStream jsonStream = new ByteArrayOutputStream();
+        try (XContentBuilder jsonBuilder = XContentType.JSON.contentBuilder(jsonStream)) {
+            settings.toXContent(jsonBuilder, Settings.EMPTY_PARAMS);
+        }
+        byte[] settingsJson = jsonStream.toByteArray();
+        
+        // Write to etcd
+        publishToEtcd(settingsPath, settingsJson, "settings for index " + indexName);
+    }
+
+    /**
+     * Publishes only index mappings to etcd.
+     * 
+     * @param indexName the name of the index
+     * @param mappingMetadata the mapping metadata to publish
+     * @throws IOException if serialization fails
+     * @throws RuntimeException if etcd operations fail
+     */
+    public void publishIndexMappings(String indexName, MappingMetadata mappingMetadata) throws IOException {
+        String mappingsPath = ETCDPathUtils.buildIndexMappingsPath(clusterName, indexName);
+        
+        // Serialize mappings to JSON
+        ByteArrayOutputStream jsonStream = new ByteArrayOutputStream();
+        try (XContentBuilder jsonBuilder = XContentType.JSON.contentBuilder(jsonStream)) {
+            jsonBuilder.map(mappingMetadata.sourceAsMap());
+        }
+        byte[] mappingsJson = jsonStream.toByteArray();
+        
+        // Write to etcd
+        publishToEtcd(mappingsPath, mappingsJson, "mappings for index " + indexName);
+    }
+
+    /**
+     * Removes index metadata from etcd by deleting all related entries.
+     * This should be called when an index is deleted.
+     * 
+     * @param indexName the name of the index to remove
+     */
+    public void removeIndexMetadata(String indexName) {
+        LOGGER.debug("Removing split index metadata for index [{}]", indexName);
+        
+        try (KV kvClient = etcdClient.getKVClient()) {
+            String settingsPath = ETCDPathUtils.buildIndexSettingsPath(clusterName, indexName);
+            String mappingsPath = ETCDPathUtils.buildIndexMappingsPath(clusterName, indexName);
+            
+            // Delete all entries concurrently
+            CompletableFuture<Void> settingsDelete = kvClient.delete(ByteSequence.from(settingsPath, StandardCharsets.UTF_8))
+                .thenApply(response -> null);
+            CompletableFuture<Void> mappingsDelete = kvClient.delete(ByteSequence.from(mappingsPath, StandardCharsets.UTF_8))
+                .thenApply(response -> null);
+            
+            // Wait for all deletions to complete
+            CompletableFuture.allOf(settingsDelete, mappingsDelete).get();
+            
+            LOGGER.debug("Successfully removed split index metadata for index [{}]", indexName);
+        } catch (InterruptedException | ExecutionException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new RuntimeException("Failed to remove index metadata from etcd for index " + indexName, e);
+        }
+    }
+
+    /**
+     * Extracts relevant settings from the full index settings, filtering out fields that should 
+     * be populated by the plugin rather than stored in etcd.
+     */
+    private Settings extractRelevantSettings(Settings originalSettings) {
+        Settings.Builder filteredSettings = Settings.builder();
+        
+        // Filter out settings that are populated as constants in the plugin
+        for (String key : originalSettings.keySet()) {
+            // Skip settings that the plugin populates as constants
+            if (shouldFilterOutSetting(key)) {
+                continue;
+            }
+            filteredSettings.put(key, originalSettings.get(key));
+        }
+        
+        return filteredSettings.build();
+    }
+    
+    /**
+     * Determines if a setting should be filtered out (not stored in etcd) because
+     * it's populated as a constant in the plugin.
+     */
+    private boolean shouldFilterOutSetting(String settingKey) {
+        // Filter out settings that might be constants in the future
+        if (settingKey.startsWith("constant")) { // This is a placeholder for future constants
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Helper method to publish data to etcd.
+     */
+    private void publishToEtcd(String path, byte[] data, String description) {
+        try (KV kvClient = etcdClient.getKVClient()) {
+            ByteSequence key = ByteSequence.from(path, StandardCharsets.UTF_8);
+            ByteSequence value = ByteSequence.from(data);
+            
+            kvClient.put(key, value).get();
+            LOGGER.trace("Successfully published {} to etcd path [{}]", description, path);
+        } catch (InterruptedException | ExecutionException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new RuntimeException("Failed to publish " + description + " to etcd", e);
+        }
+    }
+} 

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
@@ -31,8 +31,37 @@ public class ETCDPathUtils {
         return buildSearchUnitActualStatePath(clusterName, nodeName);
     }
     
+    /**
+     * @deprecated Use buildIndexSettingsPath, buildIndexMappingsPath, or buildIndexOtherPath instead.
+     * This method returns the legacy path for complete index metadata blob.
+     */
+    @Deprecated
     public static String buildIndexConfigPath(String clusterName, String indexName) {
         return clusterName + "/indices/" + indexName + "/conf";
+    }
+    
+    /**
+     * Builds the etcd path for index settings.
+     * Index settings are needed by both data nodes and coordinator nodes.
+     * 
+     * @param clusterName the cluster name
+     * @param indexName the index name
+     * @return the etcd path for index settings
+     */
+    public static String buildIndexSettingsPath(String clusterName, String indexName) {
+        return clusterName + "/indices/" + indexName + "/settings";
+    }
+    
+    /**
+     * Builds the etcd path for index mappings.
+     * Index mappings are needed by data nodes only.
+     * 
+     * @param clusterName the cluster name
+     * @param indexName the index name
+     * @return the etcd path for index mappings
+     */
+    public static String buildIndexMappingsPath(String clusterName, String indexName) {
+        return clusterName + "/indices/" + indexName + "/mappings";
     }
     
     public static String buildShardPlannedAllocationPath(String clusterName, String indexName, int shardId) {

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
@@ -238,34 +238,38 @@ public class ETCDStateDeserializer {
         try {
             // Fetch and parse settings
             GetResponse settingsResponse = settingsFuture.get();
-            if (!settingsResponse.getKvs().isEmpty()) {
-                KeyValue settingsKv = settingsResponse.getKvs().get(0);
-                try (XContentParser parser = JsonXContent.jsonXContent.createParser(
-                    NamedXContentRegistry.EMPTY, 
-                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION, 
-                    settingsKv.getValue().getBytes()
-                )) {
-                    indexSettings = Settings.fromXContent(parser);
-                }
+            if (settingsResponse.getKvs().isEmpty()) {
+                throw new IllegalStateException("Settings response is empty");
             }
+            KeyValue settingsKv = settingsResponse.getKvs().get(0);
+            try (XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY, 
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, 
+                settingsKv.getValue().getBytes()
+            )) {
+                indexSettings = Settings.fromXContent(parser);
+            }
+        
             
             // Fetch and parse mappings
             GetResponse mappingsResponse = mappingsFuture.get();
-            if (!mappingsResponse.getKvs().isEmpty()) {
-                KeyValue mappingsKv = mappingsResponse.getKvs().get(0);
-                try (XContentParser parser = JsonXContent.jsonXContent.createParser(
-                    NamedXContentRegistry.EMPTY, 
-                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION, 
-                    mappingsKv.getValue().getBytes()
-                )) {
-                    // Parse the mapping JSON and create MappingMetadata
-                    Map<String, Object> mappingMap = parser.map();
-                    if (!mappingMap.isEmpty()) {
-                        // Assume single mapping type for simplicity 
-                        mappingMetadata = new MappingMetadata("_doc", mappingMap);
-                    }
+            if (mappingsResponse.getKvs().isEmpty()) {
+                throw new IllegalStateException("Mappings response is empty");
+            }
+            KeyValue mappingsKv = mappingsResponse.getKvs().get(0);
+            try (XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY, 
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, 
+                mappingsKv.getValue().getBytes()
+            )) {
+                // Parse the mapping JSON and create MappingMetadata
+                Map<String, Object> mappingMap = parser.map();
+                if (!mappingMap.isEmpty()) {
+                    // Assume single mapping type for simplicity 
+                    mappingMetadata = new MappingMetadata("_doc", mappingMap);
                 }
             }
+            
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException("Failed to fetch index metadata parts from etcd", e);
         }

--- a/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
+++ b/plugins/cluster-etcd/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
@@ -22,6 +22,7 @@ import org.opensearch.cluster.etcd.changeapplier.NodeState;
 import org.opensearch.cluster.etcd.changeapplier.RemoteNode;
 import org.opensearch.cluster.etcd.changeapplier.ShardRole;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.index.Index;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import org.opensearch.common.settings.Settings;
 
 /**
  * Sample JSON:
@@ -182,17 +184,23 @@ public class ETCDStateDeserializer {
         Map<String, Map<Integer, ShardRole>> localShardAssignment = new HashMap<>();
         Map<String, IndexMetadata> indexMetadataMap = new HashMap<>();
         try (KV kvClient = etcdClient.getKVClient()) {
-            List<CompletableFuture<GetResponse>> futures = new ArrayList<>();
+            // Prepare futures for fetching settings and mappings separately
+            List<CompletableFuture<GetResponse>> settingsFutures = new ArrayList<>();
+            List<CompletableFuture<GetResponse>> mappingsFutures = new ArrayList<>();
             List<String> indexNames = new ArrayList<>();
             
             for (Map.Entry<String, Map<String, String>> entry : localShards.entrySet()) {
                 String indexName = entry.getKey();
                 indexNames.add(indexName);
                 
-                // Use the standardized path for index configuration
-                String indexConfigPath = ETCDPathUtils.buildIndexConfigPath(clusterName, indexName);
-                futures.add(kvClient.get(ByteSequence.from(indexConfigPath, StandardCharsets.UTF_8)));
+                // Fetch settings and mappings from separate etcd paths
+                String indexSettingsPath = ETCDPathUtils.buildIndexSettingsPath(clusterName, indexName);
+                String indexMappingsPath = ETCDPathUtils.buildIndexMappingsPath(clusterName, indexName);
                 
+                settingsFutures.add(kvClient.get(ByteSequence.from(indexSettingsPath, StandardCharsets.UTF_8)));
+                mappingsFutures.add(kvClient.get(ByteSequence.from(indexMappingsPath, StandardCharsets.UTF_8)));
+                
+                // Process shard assignments
                 Map<String, String> shards = entry.getValue();
                 for (Map.Entry<String, String> shardEntry : shards.entrySet()) {
                     String shardId = shardEntry.getKey();
@@ -201,23 +209,105 @@ public class ETCDStateDeserializer {
                 }
             }
             
-            for (int i = 0; i < futures.size(); i++) {
+            // Process the results
+            for (int i = 0; i < indexNames.size(); i++) {
                 String indexName = indexNames.get(i);
-                GetResponse getResponse;
-                try {
-                    getResponse = futures.get(i).get();
-                } catch (InterruptedException | ExecutionException e) {
-                    throw new RuntimeException(e);
-                }
-                for (KeyValue kv : getResponse.getKvs()) {
-                    try(XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, kv.getValue().getBytes())) {
-                        IndexMetadata indexMetadata = IndexMetadata.fromXContent(parser);
-                        indexMetadataMap.put(indexName, indexMetadata);
-                    }
-                }
+                IndexMetadata indexMetadata = buildIndexMetadataFromSeparateParts(
+                    indexName, 
+                    settingsFutures.get(i), 
+                    mappingsFutures.get(i)
+                );
+                indexMetadataMap.put(indexName, indexMetadata);
             }
         }
         return new DataNodeState(localNode, indexMetadataMap, localShardAssignment);
+    }
+    
+    /**
+     * Builds IndexMetadata from separate settings and mappings etcd responses.
+     * Also populates constant values that don't need to be stored in etcd.
+     */
+    private static IndexMetadata buildIndexMetadataFromSeparateParts(
+        String indexName, 
+        CompletableFuture<GetResponse> settingsFuture, 
+        CompletableFuture<GetResponse> mappingsFuture
+    ) throws IOException {
+        Settings indexSettings = null;
+        MappingMetadata mappingMetadata = null;
+        
+        try {
+            // Fetch and parse settings
+            GetResponse settingsResponse = settingsFuture.get();
+            if (!settingsResponse.getKvs().isEmpty()) {
+                KeyValue settingsKv = settingsResponse.getKvs().get(0);
+                try (XContentParser parser = JsonXContent.jsonXContent.createParser(
+                    NamedXContentRegistry.EMPTY, 
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION, 
+                    settingsKv.getValue().getBytes()
+                )) {
+                    indexSettings = Settings.fromXContent(parser);
+                }
+            }
+            
+            // Fetch and parse mappings
+            GetResponse mappingsResponse = mappingsFuture.get();
+            if (!mappingsResponse.getKvs().isEmpty()) {
+                KeyValue mappingsKv = mappingsResponse.getKvs().get(0);
+                try (XContentParser parser = JsonXContent.jsonXContent.createParser(
+                    NamedXContentRegistry.EMPTY, 
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION, 
+                    mappingsKv.getValue().getBytes()
+                )) {
+                    // Parse the mapping JSON and create MappingMetadata
+                    Map<String, Object> mappingMap = parser.map();
+                    if (!mappingMap.isEmpty()) {
+                        // Assume single mapping type for simplicity 
+                        mappingMetadata = new MappingMetadata("_doc", mappingMap);
+                    }
+                }
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("Failed to fetch index metadata parts from etcd", e);
+        }
+        
+        // Build IndexMetadata with both etcd-sourced and constant values
+        return buildIndexMetadataWithConstants(indexName, indexSettings, mappingMetadata);
+    }
+    
+    /**
+     * Builds IndexMetadata with settings and mappings from etcd, plus constant values 
+     * that are populated in the plugin rather than stored in etcd.
+     */
+    private static IndexMetadata buildIndexMetadataWithConstants(
+        String indexName, 
+        Settings indexSettings, 
+        MappingMetadata mappingMetadata
+    ) {
+        // Start with etcd-sourced settings
+        Settings.Builder settingsBuilder = indexSettings != null ? 
+            Settings.builder().put(indexSettings) : 
+            Settings.builder();
+      
+
+        // This is just an example of how constants could be populated in the plugin.
+        // Build IndexMetadata
+        Settings finalSettings = settingsBuilder.build();
+        IndexMetadata.Builder metadataBuilder = IndexMetadata.builder(indexName)
+            .settings(finalSettings);
+            
+        // Add mapping if present
+        if (mappingMetadata != null) {
+            metadataBuilder.putMapping(mappingMetadata);
+        }
+        
+        // Set primary terms for each shard (these are constants that don't need to be in etcd)
+        // Get number of shards from settings
+        int numberOfShards = finalSettings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1);
+        for (int i = 0; i < numberOfShards; i++) {
+            metadataBuilder.primaryTerm(i, 1); 
+        }
+        
+        return metadataBuilder.build();
     }
 
 


### PR DESCRIPTION

### Description
-  Split index metadata into separate etcd paths: /settings, /mappings
- Update data node reading logic to fetch settings and mappings in parallel
- Update README with new format and migration guide

